### PR TITLE
Update `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 **__pycache__
 /.spyproject
-/src/notebooks/results
-/src/notebooks/.ipynb_checkpoints
-/src/hogben/__pycache__
-/src/hogben/models/__pycache__
-/src/hogben/results/
-/dist
-/src/hogben/HOGBEN.egg-info
+/examples/results
+/hogben/__pycache__
+/hogben/models/__pycache__
+/hogben/results/
+/hogben/HOGBEN.egg-info
+/notebooks/results
+/notebooks/.ipynb_checkpoints


### PR DESCRIPTION
Fixes issue #50

This updates the `.gitignore` file so that it points to the directories as located in the root folder of this project. I am not sure if anythihng is packaged in an egg in the first place, and whether the associated info file should be removed, but I kept it in there to be safe.