### PR TITLE
Add unit tests for `fisher` function in `utils`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 **__pycache__
+.*
 /.spyproject
 /examples/results
-/hogben/__pycache__
-/hogben/models/__pycache__
 /hogben/results/
 /hogben/HOGBEN.egg-info
 /notebooks/results

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -50,7 +50,7 @@ def get_mock_reflectivity(data_points):
     Mocks the reflectivity values in the calculation, values are changed between each call
     to mimic a changing parameter in the model. Value should always be between 0 and 1.
     """
-    r = [i / data_points for i in range(data_points+1)]  # Create reflectivity values from 0 to 1
+    r = [i / data_points for i in range(data_points)]  # Create reflectivity values from 0 to approx. 1
     while True:
         r = [abs(value - 0.43) for value in r]  # Change reflectivity after each call
         yield r

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -1,42 +1,16 @@
-import bumps
+import bumps.parameter
 import numpy as np
 import pytest
 import refnx
+import refl1d.experiment
 
 from hogben.simulate import simulate
 from hogben.utils import fisher
 from refnx.reflect import SLD as SLD_refnx
 from refl1d.material import SLD as SLD_refl1d
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-
-class MockXi:
-    """Mock of Xi, list of varying parameters"""
-
-    def __init__(self, values):
-        self._elements = [MockXiElement(value) for value in values]
-
-    def __getitem__(self, index):
-        return self._elements[index]
-
-    def __len__(self):
-        return len(self._elements)
-
-
-class MockXiElement:
-    """Mock of the elements in Xi, allows to call for the value attribute"""
-
-    def __init__(self, value):
-        self._value = value
-
-    @property
-    def value(self):
-        return self._value
-
-    @value.setter
-    def value(self, new_value):
-        self._value = new_value
-
+Q_VALUES=np.array([[0.1, 0.2, 0.4, 0.6, 0.8]])
 
 @pytest.fixture
 def refl1d_model():
@@ -45,20 +19,20 @@ def refl1d_model():
     air = SLD_refl1d(rho=0, name='Air')
     layer1 = SLD_refl1d(rho=4, name='Layer 1')(thickness=60, interface=8)
     layer2 = SLD_refl1d(rho=8, name='Layer 2')(thickness=150, interface=2)
+    substrate = SLD_refl1d(rho=2.047, name='Substrate')(thickness=0,
+                                                        interface=2)
     layer1.thickness.pmp(10)  # Set 10% interval on bounds
     layer2.thickness.pmp(10)
     layer1.interface.pmp(10)
     layer2.interface.pmp(10)
-    substrate = SLD_refl1d(rho=2.047, name='Substrate')(thickness=0,
-                                                        interface=2)
     sample = substrate | layer2 | layer1 | air
+
     # Define model
     angle_times = [(0.7, 100, 5), (2.0, 100, 20)]  # (Angle, Points, Time)
     model, _ = simulate(sample, angle_times)
     model.xi = [layer1.interface, layer2.interface, layer1.thickness,
                 layer2.thickness]
     return model
-
 
 @pytest.fixture
 def refnx_model():
@@ -79,146 +53,184 @@ def refnx_model():
                 layer2.thick]  # Default free model parameters
     return model
 
+@pytest.fixture
+def mock_refnx_model():
+    """Define a bilayer sample, and return the associated refnx model"""
+    # Define sample
+    parameter_values = [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5,
+                                                                       2.5)]
+    parameters = [
+        Mock(spec=refnx.analysis.Parameter, value=value,
+             bounds=Mock(lb=lb, ub=ub))
+        for value, lb, ub in parameter_values
+    ]
+    model = Mock(spec=refnx.reflect.ReflectModel, xi=parameters)
+    model.xi = parameters
+    return model
 
-# @patch('hogben.utils.reflectivity')
+@pytest.fixture
+def mock_refl1d_model():
+    """Define a bilayer sample, and return the associated refnx model"""
+    # Define sample
+    parameter_values = [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5,
+                                                                       2.5)]
+    parameters = [
+        Mock(spec=bumps.parameter.Parameter, value=value,
+             bounds=Mock(limits=[lb, ub]))
+        for value, lb, ub in parameter_values
+    ]
+    model = Mock(spec=refl1d.experiment.Experiment, xi=parameters)
+    model.xi = parameters
+    return model
+
 def get_fisher_information(model, xi=None, counts=None,
                            qs=None, step=0.005):
     """Obtains the Fisher matrix, and defines the used model parameters"""
     # Provide default values for qs, counts and xi
     if qs is None:
-        qs = np.array(
-            [[0.1, 0.2, 0.4, 0.6, 0.8]])  # Define default array of qs
+        qs = Q_VALUES  # Define default array of qs
     if counts is None:
-        counts = [np.ones(len(qs[0])) * 500]  # Define 500 counts at each q
+        counts = [np.ones(len(qs[0])) * 100]  # Define 100 counts at each q
     if xi is None:
         xi = model.xi
     return fisher(qs, xi, counts, [model], step)
 
-
-@patch('hogben.utils.reflectivity')
-@patch('hogben.utils._get_bounds')
-def get_fisher_mock(mock_bounds, mock_reflectivity, counts=None,
-                    bounds=None, qs=None, xi=None):
-    """Obtains a mocked Fisher matrix, without actually calculating the
-    reflectivity or model. Allows for custom inputs on the q values,
-    parameter values and bounds.
+def get_reflectivity_from_datapoints(data_points):
     """
-    # Provide default values for qs, xi, counts and bounds
-    if qs is None:
-        qs = [[0.1, 0.2, 0.4, 0.6, 0.8]]
-    if xi is None:
-        xi = MockXi([8, 2, 60, 150])
-    if counts is None:
-        counts = [np.ones(len(qs[0])) * 500] # Define 500 counts at each q
-    if bounds is None:
-        # Default bounds list should have equal length as xi (one per param)
-        # lower bound should always be lower than upper bound
-        mock_bounds.return_value = \
-            np.linspace(1, 100, len(xi)), np.linspace(101, 200, len(xi))
-    else:
-        mock_bounds.return_value = bounds[0], bounds[1]
-    mock_reflectivity.side_effect = get_mock_reflectivity(len(qs[0]))
-    return fisher(qs, xi, counts, [[]])
-
-
-def get_mock_reflectivity(data_points):
-    """
-    Mocks the reflectivity values in the calculation, values are changed between each call
-    to mimic a changing parameter in the model. Value should always be between 0 and 1.
+    Mocks the reflectivity values in the calculation, values are changed
+    between each call to mimic a changing parameter in the model. Value
+    should always be between 0 and 1.
     """
     r = list(np.linspace(1, 0, num=data_points))  # Reflectivity from 1 to 0
     while True:
-        r = [abs(value - 0.43) for value in
-             r]  # Change reflectivity after each call
+        r = [abs(value - 0.47) for value in r]  # Change reflectivity after
+        # each call
         yield r
 
+def get_mock_reflectivity():
+    """
+    Mocks the reflectivity values in the calculation, values are changed
+    between each call to mimic a changing parameter in the model. Value
+    should always be between 0 and 1.
+    """
+    r = [[1.0, 0.5, 0.4, 0.2, 0.1], [0.95, 0.45, 0.35, 0.15, 0.05]]
+    while True:
+        yield r[0]
+        yield r[1]
 
-def test_fisher_information_values_refnx(refnx_model):
+def test_fisher_workflow_refnx(refnx_model):
     """
     Tests that all the calculated Fisher information matrix returns the expected values
     for a given set of parameters
     """
     g = get_fisher_information(refnx_model, step=0.005)
     expected_fisher = [
-        [6.47130383e-06, 5.60447670e-06, -8.37036590e-07, -4.94928881e-07],
-        [5.60447670e-06, 5.02797639e-06, -6.98112513e-07, -3.98228927e-07],
-        [-8.37036590e-07, -6.98112513e-07, 1.27921607e-07, 8.59517503e-08],
-        [-4.94928881e-07, -3.98228927e-07, 8.59517503e-08, 6.23346359e-08]]
-    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
+        [1.29426077e-06, 1.12089534e-06, -1.67407318e-07, -9.89857761e-08],
+        [1.12089534e-06, 1.00559528e-06, -1.39622503e-07, -7.96457855e-08],
+        [-1.67407318e-07, -1.39622503e-07, 2.55843215e-08, 1.71903501e-08],
+        [-9.89857761e-08, -7.96457855e-08, 1.71903501e-08, 1.24669272e-08]
+    ]
+    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08)
 
 
-def test_fisher_information_values_ref1d(refl1d_model):
+def test_fisher_workflow_refl1d(refl1d_model):
     """
-    Tests that all the calculated Fisher information matrix returns the expected values
-    for a given set of parameters
+    Tests that all the calculated Fisher information matrix returns the
+    expected values for a given set of parameters
     """
     g = get_fisher_information(refl1d_model, step=0.005)
     expected_fisher = [
-        [3.58042704e-05, 6.49102395e-05, -4.40696428e-06, -2.83582010e-06],
-        [6.49102395e-05, 1.22021923e-04, -7.66739810e-06, -4.72522420e-06],
-        [-4.40696428e-06, -7.66739810e-06, 6.26586892e-07, 4.56331772e-07],
-        [-2.83582010e-06, -4.72522420e-06, 4.56331772e-07, 3.61390847e-07]]
-    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
+        [7.16085407e-06, 1.29820479e-05, -8.81392856e-07, -5.67164020e-07],
+        [1.29820479e-05, 2.44043845e-05, -1.53347962e-06, -9.45044841e-07],
+        [-8.81392856e-07, -1.53347962e-06, 1.25317378e-07, 9.12663545e-08],
+        [-5.67164020e-07, -9.45044841e-07, 9.12663545e-08, 7.22781693e-08]
+    ]
+    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08)
 
+@patch('hogben.utils.reflectivity')
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                       "mock_refnx_model"))
+def test_fisher_correct_values(mock_reflectivity, model_class, request):
+    """
+    Tests that the values of the calculated Fisher information matrix
+    are calculated correctly.
+    """
+    model = request.getfixturevalue(model_class)
+    xi = model.xi[:3]
+    mock_reflectivity.side_effect = get_mock_reflectivity()
+    g_correct = [[1.28125, 0.5125, 25.625],
+                [0.5125, 0.205, 10.25],
+                [25.625, 10.25, 512.5]]
+    g_reference = get_fisher_information(model, xi = xi)
+    np.testing.assert_allclose(g_reference, g_correct, rtol=1e-08)
 
+@pytest.mark.parametrize('model_class', ("refl1d_model",
+                                       "refnx_model"))
 @pytest.mark.parametrize('step', (0.01, 0.0075, 0.0025, 0.001, 0.0001))
-def test_fisher_consistent_steps_refnx(step, refnx_model):
+def test_fisher_consistent_steps(step,  model_class, request):
     """
     Tests whether the Fisher information remains mostly consistent when
     changing step size using the refnx model
     """
-    g_reference = get_fisher_information(refnx_model, step=0.005)
-    g_compare = get_fisher_information(refnx_model, step=step)
+    model = request.getfixturevalue(model_class)
+    g_reference = get_fisher_information(model, step=0.005)
+    g_compare = get_fisher_information(model, step=step)
     np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
 
-
-@pytest.mark.parametrize('step', (0.01, 0.0075, 0.0025, 0.001, 0.0001))
-def test_fisher_consistent_steps_refl1d(step, refl1d_model):
-    """
-    Tests whether the Fisher information remains mostly consistent when
-    changing step size using the refl1d model
-    """
-    g_reference = get_fisher_information(refl1d_model, step=0.005)
-    g_compare = get_fisher_information(refl1d_model, step=step)
-    np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
-
-
+@patch('hogben.utils.reflectivity')
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                       "mock_refnx_model"))
 @pytest.mark.parametrize('model_params', (1, 2, 3, 4))
-def test_fisher_shape(model_params):
+def test_fisher_shape(mock_reflectivity, model_params, model_class, request):
     """
     Tests whether the shape of the Fisher information matrix remains
      correct when changing the amount of parameters
     """
-    xi = MockXi([8, 2, 60, 150])[:model_params]
-    bounds = [np.array([6.0, 1.0, 40, 100][:model_params]),
-              np.array([10, 3, 70, 180][:model_params])]
+    model = request.getfixturevalue(model_class)
+    xi = model.xi[:model_params]
+
+    qs = Q_VALUES
+    mock_reflectivity.side_effect = get_mock_reflectivity()
+
     expected_shape = (model_params, model_params)
-    g = get_fisher_mock(bounds=bounds, xi=xi)
+    g = get_fisher_information(None, xi=xi)
     np.testing.assert_array_equal(g.shape, expected_shape)
 
-
+@patch('hogben.utils.reflectivity')
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                       "mock_refnx_model"))
 @pytest.mark.parametrize('qs',
                          (np.arange(0.001, 1.0, 0.25),
                           np.arange(0.001, 1.0, 0.10),
                           np.arange(0.001, 1.0, 0.05),
                           np.arange(0.001, 1.0, 0.01)))
-def test_fisher_diagonal_positive(qs):
+def test_fisher_diagonal_positive(mock_reflectivity, qs, model_class, request):
     """Tests whether the diagonal values in the Fisher information matrix
      are positively valued"""
-    qs = [0.1, 0.2, 0.4, 0.6, 0.8]
-    g = get_fisher_mock(qs=[qs])
+    model = request.getfixturevalue(model_class)
+    mock_reflectivity.side_effect = get_reflectivity_from_datapoints(len(qs))
+    g = get_fisher_information(model, qs=[qs])
     np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))
 
-
-@pytest.mark.parametrize('xi',
-                         (MockXi([]),
-                          MockXi([8]),
-                          MockXi([8, 2]),
-                          MockXi([8, 2, 60]),
-                          MockXi([8, 2, 60, 150])))
-def test_fisher_no_data(xi):
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                       "mock_refnx_model"))
+@pytest.mark.parametrize('model_params', (1, 2, 3, 4))
+def test_fisher_no_data(model_params, model_class, request):
     """Tests whether a model with zero data points properly returns a
     zero array"""
+    model = request.getfixturevalue(model_class)
+    xi = model.xi[:model_params]
     qs = []
-    g = get_fisher_mock(qs=[qs], xi=xi)
+    g = get_fisher_information(model, qs=[qs], xi=xi)
     np.testing.assert_equal(g, np.zeros((len(xi), len(xi))))
+
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                       "mock_refnx_model"))
+@patch('hogben.utils.reflectivity')
+def test_fisher_no_parameters(mock_reflectivity, model_class, request):
+    """Tests whether a model with zero data points properly returns a
+    zero array"""
+    model = request.getfixturevalue(model_class)
+    mock_reflectivity.side_effect = get_mock_reflectivity()
+    g = get_fisher_information(model, xi=[])
+    np.testing.assert_equal(g.shape, (0,0))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -285,15 +285,15 @@ def test_fisher_shape(mock_reflectivity, model_params, model_class, request):
                           np.arange(0.001, 1.0, 0.10),
                           np.arange(0.001, 1.0, 0.05),
                           np.arange(0.001, 1.0, 0.01)))
-def test_fisher_diagonal_positive(mock_reflectivity, qs, model_class, request):
+def test_fisher_diagonal_non_negative(mock_reflectivity, qs, model_class,
+                                   request):
     """Tests whether the diagonal values in the Fisher information matrix
-     are positively valued"""
+     are all zero or greater"""
     model = request.getfixturevalue(model_class)
     mock_reflectivity.side_effect = (np.random.rand(len(qs)) for _ in range(9))
     counts = [np.ones(len(qs)) * 100]
     g = fisher([qs], model.xi, counts, [model])
-    np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))
-
+    assert min(np.diag(g)) >= 0 # Check if smallest value is at least zero
 
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
                                          "mock_refnx_model"))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -216,7 +216,7 @@ def test_fisher_diagonal_positive(qs):
                           MockXi([8, 2]),
                           MockXi([8, 2, 60]),
                           MockXi([8, 2, 60, 150])))
-def test_no_data(xi):
+def test_fisher_no_data(xi):
     """Tests whether a model with zero data points properly returns a
     zero array"""
     qs = []

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -62,7 +62,7 @@ def mock_refnx_model():
     Create a mock of the refl1d model with a given set of parameters and their
     bounds
     """
-    # Parameters described as tuples: (value, left bound, right bound)
+    # Parameters described as tuples: (value, lower bound, upper bound)
     parameter_values = \
         [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5, 2.5)]
 
@@ -83,7 +83,7 @@ def mock_refl1d_model():
     Create a mock of the refl1d model with a given set of parameters and their
     bounds
     """
-    # Parameters described as tuples: (value, left bound, right bound)
+    # Parameters described as tuples: (value, lower bound, upper bound)
     parameter_values = \
         [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5, 2.5)]
 

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -9,8 +9,10 @@ from refnx.reflect import SLD as SLD_refnx
 from refl1d.material import SLD as SLD_refl1d
 from unittest.mock import patch
 
+
 class MockXi:
     """Mock of Xi, list of varying parameters"""
+
     def __init__(self, values):
         self._elements = [MockXiElement(value) for value in values]
 
@@ -20,8 +22,10 @@ class MockXi:
     def __len__(self):
         return len(self._elements)
 
+
 class MockXiElement:
     """Mock of the elements in Xi, allows to call for the value attribute"""
+
     def __init__(self, value):
         self._value = value
 
@@ -36,7 +40,7 @@ class MockXiElement:
 
 @pytest.fixture
 def refl1d_model():
-    """Define a bilayer sample, and return the associated refnx model"""
+    """Define a bilayer sample, and return the associated refl1d model"""
     # Define sample
     air = SLD_refl1d(rho=0, name='Air')
     layer1 = SLD_refl1d(rho=4, name='Layer 1')(thickness=60, interface=8)
@@ -45,7 +49,8 @@ def refl1d_model():
     layer2.thickness.pmp(10)
     layer1.interface.pmp(10)
     layer2.interface.pmp(10)
-    substrate = SLD_refl1d(rho=2.047, name='Substrate')(thickness=0, interface=2)
+    substrate = SLD_refl1d(rho=2.047, name='Substrate')(thickness=0,
+                                                        interface=2)
     sample = substrate | layer2 | layer1 | air
     # Define model
     angle_times = [(0.7, 100, 5), (2.0, 100, 20)]  # (Angle, Points, Time)
@@ -57,7 +62,7 @@ def refl1d_model():
 
 @pytest.fixture
 def refnx_model():
-    """Define a bilayer sample, and return the associated refl1d model"""
+    """Define a bilayer sample, and return the associated refnx model"""
     # Define sample
     air = SLD_refnx(0, name='Air')
     layer1 = SLD_refnx(4, name='Layer 1')(thick=60, rough=8)
@@ -70,40 +75,49 @@ def refnx_model():
     sample = air | layer1 | layer2 | substrate
     model = refnx.reflect.ReflectModel(sample, scale=1, bkg=5e-6, dq=2)
     # Define model
-    model.xi = [layer1.rough, layer2.rough, layer1.thick, layer2.thick]  # Default free model parameters
+    model.xi = [layer1.rough, layer2.rough, layer1.thick,
+                layer2.thick]  # Default free model parameters
     return model
 
 
 # @patch('hogben.utils.reflectivity')
-def get_fisher_information(model, qs=None, xi=None):
+def get_fisher_information(model, xi=None, counts=None,
+                           qs=None, step=0.005):
     """Obtains the Fisher matrix, and defines the used model parameters"""
+    # Provide default values for qs, counts and xi
     if qs is None:
-        qs = np.array([[0.1, 0.2, 0.4, 0.6, 0.8]])  # Define default array of qs
-    counts = [np.ones(len(qs[0])) * 500]  # Define 500 counts at each q point
+        qs = np.array(
+            [[0.1, 0.2, 0.4, 0.6, 0.8]])  # Define default array of qs
+    if counts is None:
+        counts = [np.ones(len(qs[0])) * 500]  # Define 500 counts at each q
     if xi is None:
         xi = model.xi
-    return fisher(qs, xi, counts, [model])
+    return fisher(qs, xi, counts, [model], step)
 
 
 @patch('hogben.utils.reflectivity')
 @patch('hogben.utils._get_bounds')
-def get_fisher_mock(mock_bounds, mock_reflectivity, bounds = None, qs = None,
-                    xi = None):
+def get_fisher_mock(mock_bounds, mock_reflectivity, counts=None,
+                    bounds=None, qs=None, xi=None):
     """Obtains a mocked Fisher matrix, without actually calculating the
     reflectivity or model. Allows for custom inputs on the q values,
     parameter values and bounds.
     """
-    if qs == None:
+    # Provide default values for qs, xi, counts and bounds
+    if qs is None:
         qs = [[0.1, 0.2, 0.4, 0.6, 0.8]]
     if xi is None:
-        xi = MockXi([8, 2, 60 , 150])
-    counts = [np.ones(len(qs[0])) * 500]  # Define 500 counts at each q point
-    mock_reflectivity.side_effect = get_mock_reflectivity(len(qs[0]))
+        xi = MockXi([8, 2, 60, 150])
+    if counts is None:
+        counts = [np.ones(len(qs[0])) * 500] # Define 500 counts at each q
     if bounds is None:
+        # Default bounds list should have equal length as xi (one per param)
+        # lower bound should always be lower than upper bound
         mock_bounds.return_value = \
-            np.array([6.0, 1.0, 40, 100]), np.array([10, 3, 70, 180])
+            np.linspace(1, 100, len(xi)), np.linspace(101, 200, len(xi))
     else:
         mock_bounds.return_value = bounds[0], bounds[1]
+    mock_reflectivity.side_effect = get_mock_reflectivity(len(qs[0]))
     return fisher(qs, xi, counts, [[]])
 
 
@@ -112,75 +126,99 @@ def get_mock_reflectivity(data_points):
     Mocks the reflectivity values in the calculation, values are changed between each call
     to mimic a changing parameter in the model. Value should always be between 0 and 1.
     """
-    if data_points == 0:
-        r = []
-    else:
-        r = list(np.arange(1, 0, -1 / data_points))  # Decaying reflectivity from 1 to 0
+    r = list(np.linspace(1, 0, num=data_points))  # Reflectivity from 1 to 0
     while True:
-        r = [abs(value - 0.43) for value in r]  # Change reflectivity after each call
+        r = [abs(value - 0.43) for value in
+             r]  # Change reflectivity after each call
         yield r
 
-class Test_Fisher():
-    def test_fisher_information_values_refnx(self, refnx_model):
-        """
-        Tests that all the calculated Fisher information matrix returns the expected values
-        for a given set of parameters
-        """
-        g = get_fisher_information(refnx_model)
-        expected_fisher = [[6.47130383e-06, 5.60447670e-06, -8.37036590e-07, -4.94928881e-07],
-                           [5.60447670e-06, 5.02797639e-06, -6.98112513e-07, -3.98228927e-07],
-                           [-8.37036590e-07, -6.98112513e-07, 1.27921607e-07, 8.59517503e-08],
-                           [-4.94928881e-07, -3.98228927e-07, 8.59517503e-08, 6.23346359e-08]]
-        np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
 
-    def test_fisher_information_values_ref1d(self, refl1d_model):
-        """
-        Tests that all the calculated Fisher information matrix returns the expected values
-        for a given set of parameters
-        """
-        g = get_fisher_information(refl1d_model)
-        expected_fisher = [
-            [3.58042704e-05, 6.49102395e-05, -4.40696428e-06, -2.83582010e-06],
-            [6.49102395e-05, 1.22021923e-04, -7.66739810e-06, -4.72522420e-06],
-            [-4.40696428e-06, -7.66739810e-06, 6.26586892e-07, 4.56331772e-07],
-            [-2.83582010e-06, -4.72522420e-06, 4.56331772e-07, 3.61390847e-07]]
-        np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
+def test_fisher_information_values_refnx(refnx_model):
+    """
+    Tests that all the calculated Fisher information matrix returns the expected values
+    for a given set of parameters
+    """
+    g = get_fisher_information(refnx_model, step=0.005)
+    expected_fisher = [
+        [6.47130383e-06, 5.60447670e-06, -8.37036590e-07, -4.94928881e-07],
+        [5.60447670e-06, 5.02797639e-06, -6.98112513e-07, -3.98228927e-07],
+        [-8.37036590e-07, -6.98112513e-07, 1.27921607e-07, 8.59517503e-08],
+        [-4.94928881e-07, -3.98228927e-07, 8.59517503e-08, 6.23346359e-08]]
+    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
 
-    @pytest.mark.parametrize('model_params', (1, 2, 3, 4))
-    def test_fisher_shape(self, model_params):
-        """
-        Tests whether the shape of the Fisher information matrix remains
-         correct when changing the amount of parameters
-        """
-        xi_all = MockXi([8, 2, 60, 150])
-        xi = xi_all[:model_params]
-        bounds = [np.array([6.0, 1.0, 40, 100][:model_params]),
-                  np.array([10, 3, 70, 180][:model_params])]
-        expected_shape = (model_params, model_params)
-        g = get_fisher_mock(bounds=bounds, xi=xi)
-        np.testing.assert_array_equal(g.shape, expected_shape)
 
-    @pytest.mark.parametrize('qs',
-                             (np.arange(0.001, 1.0, 0.25),
-                              np.arange(0.001, 1.0, 0.10),
-                              np.arange(0.001, 1.0, 0.05),
-                              np.arange(0.001, 1.0, 0.01)))
-    def test_fisher_diagonal_positive(self, qs):
-        """Tests whether the diagonal values in the Fisher information matrix
-         are positively valued"""
-        qs = [0.1, 0.2, 0.4, 0.6, 0.8]
-        g = get_fisher_mock(qs=[qs])
-        np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))
+def test_fisher_information_values_ref1d(refl1d_model):
+    """
+    Tests that all the calculated Fisher information matrix returns the expected values
+    for a given set of parameters
+    """
+    g = get_fisher_information(refl1d_model, step=0.005)
+    expected_fisher = [
+        [3.58042704e-05, 6.49102395e-05, -4.40696428e-06, -2.83582010e-06],
+        [6.49102395e-05, 1.22021923e-04, -7.66739810e-06, -4.72522420e-06],
+        [-4.40696428e-06, -7.66739810e-06, 6.26586892e-07, 4.56331772e-07],
+        [-2.83582010e-06, -4.72522420e-06, 4.56331772e-07, 3.61390847e-07]]
+    np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
 
-    @pytest.mark.parametrize('xi',
-                             (MockXi([]),
-                              MockXi([8]),
-                              MockXi([8, 2]),
-                              MockXi([8, 2, 60]),
-                              MockXi([8, 2, 60, 150])))
-    def test_no_data(self, xi):
-        """Tests whether a model with zero data points properly returns a
-        zero array"""
-        qs = []
-        g = get_fisher_mock(qs=[qs], xi = xi)
-        np.testing.assert_equal(g, np.zeros((len(xi), len(xi))))
+
+@pytest.mark.parametrize('step', (0.01, 0.0075, 0.0025, 0.001, 0.0001))
+def test_fisher_consistent_steps_refnx(step, refnx_model):
+    """
+    Tests whether the Fisher information remains mostly consistent when
+    changing step size using the refnx model
+    """
+    g_reference = get_fisher_information(refnx_model, step=0.005)
+    g_compare = get_fisher_information(refnx_model, step=step)
+    np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
+
+
+@pytest.mark.parametrize('step', (0.01, 0.0075, 0.0025, 0.001, 0.0001))
+def test_fisher_consistent_steps_refl1d(step, refl1d_model):
+    """
+    Tests whether the Fisher information remains mostly consistent when
+    changing step size using the refl1d model
+    """
+    g_reference = get_fisher_information(refl1d_model, step=0.005)
+    g_compare = get_fisher_information(refl1d_model, step=step)
+    np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
+
+
+@pytest.mark.parametrize('model_params', (1, 2, 3, 4))
+def test_fisher_shape(model_params):
+    """
+    Tests whether the shape of the Fisher information matrix remains
+     correct when changing the amount of parameters
+    """
+    xi = MockXi([8, 2, 60, 150])[:model_params]
+    bounds = [np.array([6.0, 1.0, 40, 100][:model_params]),
+              np.array([10, 3, 70, 180][:model_params])]
+    expected_shape = (model_params, model_params)
+    g = get_fisher_mock(bounds=bounds, xi=xi)
+    np.testing.assert_array_equal(g.shape, expected_shape)
+
+
+@pytest.mark.parametrize('qs',
+                         (np.arange(0.001, 1.0, 0.25),
+                          np.arange(0.001, 1.0, 0.10),
+                          np.arange(0.001, 1.0, 0.05),
+                          np.arange(0.001, 1.0, 0.01)))
+def test_fisher_diagonal_positive(qs):
+    """Tests whether the diagonal values in the Fisher information matrix
+     are positively valued"""
+    qs = [0.1, 0.2, 0.4, 0.6, 0.8]
+    g = get_fisher_mock(qs=[qs])
+    np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))
+
+
+@pytest.mark.parametrize('xi',
+                         (MockXi([]),
+                          MockXi([8]),
+                          MockXi([8, 2]),
+                          MockXi([8, 2, 60]),
+                          MockXi([8, 2, 60, 150])))
+def test_no_data(xi):
+    """Tests whether a model with zero data points properly returns a
+    zero array"""
+    qs = []
+    g = get_fisher_mock(qs=[qs], xi=xi)
+    np.testing.assert_equal(g, np.zeros((len(xi), len(xi))))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -98,11 +98,11 @@ def mock_refl1d_model():
     return model
 
 
-def get_fisher_information(models,
+def get_fisher_information(models: list[Union['refnx.reflect.ReflectModel',
+                                              'refl1d.experiment.Experiment']],
                            xi: Optional[
-                               list[
-                                Union['refnx.reflect.ReflectModel',
-                                      'refl1d.experiment.Experiment']]] = None,
+                           list[Union['refnx.analysis.Parameter',
+                                      'bumps.parameter.Parameter']]] = None,
                            counts: Optional[list[int]] = None,
                            qs: Optional[list[list[float]]] = None,
                            step: float = 0.005) -> np.ndarray:

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -101,11 +101,6 @@ def mock_refl1d_model():
     return model
 
 
-def get_random_reflectivity(data_points):
-    while True:
-        yield np.random.rand(data_points)
-
-
 def generate_reflectivity_data():
     """
     Generates predefined reflectivity.The reflectivity values are yielded
@@ -255,7 +250,7 @@ def test_fisher_consistent_steps(step, model_class, request):
     model = request.getfixturevalue(model_class)
     g_reference = fisher(QS, model.xi, COUNTS, [model], step=0.005)
     g_compare = fisher(QS, model.xi, COUNTS, [model], step=step)
-    np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
+    np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02)
 
 
 @patch('hogben.utils.reflectivity')
@@ -293,7 +288,7 @@ def test_fisher_diagonal_non_negative(mock_reflectivity, qs, model_class,
     mock_reflectivity.side_effect = (np.random.rand(len(qs)) for _ in range(9))
     counts = [np.ones(len(qs)) * 100]
     g = fisher([qs], model.xi, counts, [model])
-    assert min(np.diag(g)) >= 0 # Check if smallest value is at least zero
+    assert np.all(np.diag(g)) >= 0
 
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
                                          "mock_refnx_model"))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -5,13 +5,16 @@ import numpy as np
 import pytest
 import refnx
 import refl1d.experiment
-from typing import Optional, Union
 
 from hogben.simulate import simulate
 from hogben.utils import fisher
 from refnx.reflect import SLD as SLD_refnx
 from refl1d.material import SLD as SLD_refl1d
 from unittest.mock import Mock, patch
+
+
+QS = [np.array([0.1, 0.2, 0.4, 0.6, 0.8])]
+COUNTS = [np.ones(len(QS[0])) * 100]
 
 
 @pytest.fixture
@@ -55,9 +58,6 @@ def refnx_model():
     model.xi = [layer1.rough, layer2.rough, layer1.thick, layer2.thick]
     return model
 
-QS = [np.array([0.1, 0.2, 0.4, 0.6, 0.8])]
-COUNTS = [np.ones(len(QS[0])) * 100]
-
 
 @pytest.fixture
 def mock_refnx_model():
@@ -99,6 +99,7 @@ def mock_refl1d_model():
     model = Mock(spec=refl1d.experiment.Experiment, xi=parameters)
     model.xi = parameters
     return model
+
 
 def get_random_reflectivity(data_points):
     while True:
@@ -150,8 +151,7 @@ def test_fisher_workflow_refl1d(refl1d_model):
 @patch('hogben.utils.reflectivity')
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
                                          "mock_refnx_model"))
-def test_fisher_analytical_values(mock_reflectivity, model_class,
-                                             request):
+def test_fisher_analytical_values(mock_reflectivity, model_class, request):
     """
     Tests that the values of the calculated Fisher information matrix (FIM)
     are calculated correctly when no importance scaling is given.
@@ -211,8 +211,7 @@ def test_fisher_analytical_values(mock_reflectivity, model_class,
 @patch('hogben.utils.reflectivity')
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
                                          "mock_refnx_model"))
-def test_fisher_importance_scaling(mock_reflectivity, model_class,
-                                          request):
+def test_fisher_importance_scaling(mock_reflectivity, model_class, request):
     """
     Tests that the values of the calculated Fisher information matrix
     are calculated correctly when an importance scaling is applied.

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+
+from hogben.simulate import simulate
+from hogben.utils import fisher
+from refnx.reflect import SLD
+
+
+@pytest.fixture
+def sample():
+    air = SLD(0, name='Air')
+    layer1 = SLD(4, name='Layer 1')(thick=60, rough=8)
+    layer2 = SLD(8, name='Layer 2')(thick=150, rough=2)
+    substrate = SLD(2.047, name='Substrate')(thick=0, rough=2)
+    layer1.thick.bounds = (40, 70)
+    layer2.thick.bounds = (100, 180)
+    layer1.rough.bounds = (6,10)
+    layer2.rough.bounds = (1,3)
+    return air | layer1 | layer2 | substrate
+
+
+@pytest.fixture
+def model(sample):
+    angle_times = [(0.7, 100, 5), (2.0, 100, 20)]  # (Angle, Points, Time)
+    model, _ = simulate(sample, angle_times)
+    return model
+
+
+class Test_Fisher():
+    qs = [[0.1, 0.2, 0.4, 0.6, 0.8]]
+    counts = [[500, 500, 300, 300, 400]]
+
+    @pytest.fixture(autouse=True)
+    def get_fisher_information(self, sample, model):
+        """Obtains the fisher matrix, and defines the used model parameters"""
+        self.xi = [sample[1].thick, sample[2].thick, sample[1].rough]
+        self.g = fisher(self.qs, self.xi, self.counts, [model])
+
+    def test_elements_greater_than_zero(self):
+        """
+        Tests that all diagonal elements in the Fisher matrix are greater
+        than zero
+        """
+        np.testing.assert_array_less(np.zeros(len(self.g)), np.diag(self.g))
+
+    def test_fisher_matrix_size(self):
+        """
+        Tests that the obtained Fisher matrix has the correct size
+        """
+        matrix_size = [len(self.xi), len(self.xi)]
+        g_size = [len(self.g), len(self.g[0])]
+        np.testing.assert_equal(matrix_size, g_size)

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -66,7 +66,7 @@ def mock_refnx_model():
     parameter_values = \
         [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5, 2.5)]
 
-    # Fill parameter values
+    # Fill parameter values and bounds
     parameters = [
         Mock(spec=refnx.analysis.Parameter, value=value,
              bounds=Mock(lb=lb, ub=ub))
@@ -87,7 +87,7 @@ def mock_refl1d_model():
     parameter_values = \
         [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5, 2.5)]
 
-    # Fill parameter values
+    # Fill parameter values and bounds
     parameters = [
         Mock(spec=bumps.parameter.Parameter, value=value,
              bounds=Mock(limits=[lb, ub]))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -4,49 +4,91 @@ import pytest
 from hogben.simulate import simulate
 from hogben.utils import fisher
 from refnx.reflect import SLD
+from unittest.mock import patch
 
 
 @pytest.fixture
-def sample():
+def model_fixture():
+    """Define a bilayer sample, and return the associated refnx model"""
+    # Define sample
     air = SLD(0, name='Air')
     layer1 = SLD(4, name='Layer 1')(thick=60, rough=8)
     layer2 = SLD(8, name='Layer 2')(thick=150, rough=2)
     substrate = SLD(2.047, name='Substrate')(thick=0, rough=2)
     layer1.thick.bounds = (40, 70)
     layer2.thick.bounds = (100, 180)
-    layer1.rough.bounds = (6,10)
-    layer2.rough.bounds = (1,3)
-    return air | layer1 | layer2 | substrate
+    layer1.rough.bounds = (6, 10)
+    layer2.rough.bounds = (1, 3)
+    sample = air | layer1 | layer2 | substrate
 
-
-@pytest.fixture
-def model(sample):
+    # Define model
     angle_times = [(0.7, 100, 5), (2.0, 100, 20)]  # (Angle, Points, Time)
     model, _ = simulate(sample, angle_times)
     return model
 
 
+@patch('hogben.utils.reflectivity')
+def get_fisher_information(model_fixture, mock_reflectivity, qs=None, xi=None):
+    """Obtains the Fisher matrix, and defines the used model parameters"""
+    if qs is None:
+        qs = [[0.1, 0.2, 0.4, 0.6, 0.8]]  # Define default array of qs
+    counts = [np.ones(len(qs[0])) * 500]  # Define 500 counts at each q point
+
+    layer1 = model_fixture.structure.components[1]
+    layer2 = model_fixture.structure.components[2]
+
+    if xi is None:
+        xi = [layer1.rough, layer2.rough, layer1.thick, layer2.thick]  # Default free model parameters
+
+    # Mock reflectivity from generator function
+    mock_reflectivity.side_effect = get_mock_reflectivity(len(qs[0]))
+    return fisher(qs, xi, counts, [model_fixture])
+
+
+def get_mock_reflectivity(data_points):
+    """
+    Mocks the reflectivity values in the calculation, values are changed between each call
+    to mimic a changing parameter in the model. Value should always be between 0 and 1.
+    """
+    r = [i / data_points for i in range(data_points)]  # Create reflectivity values from 0 to 1
+    while True:
+        r = [abs(value - 0.43) for value in r]  # Change reflectivity after each call
+        yield r
+
+
 class Test_Fisher():
-    qs = [[0.1, 0.2, 0.4, 0.6, 0.8]]
-    counts = [[500, 500, 300, 300, 400]]
+    def test_fisher_information_values(self, model_fixture):
+        """
+        Tests that all the calculated Fisher information matrix returns the expected values
+        for a given set of parameters
+        """
+        g = get_fisher_information(model_fixture)
+        expected_fisher = [[2.59014803e+04, 2.07211842e+05, 4.60470761e+02, 6.90706141e+01],
+                           [2.07211842e+05, 1.65769474e+06, 3.68376609e+03, 5.52564913e+02],
+                           [4.60470761e+02, 3.68376609e+03, 8.18614686e+00, 1.22792203e+00],
+                           [6.90706141e+01, 5.52564913e+02, 1.22792203e+00, 1.84188304e-01]]
+        np.testing.assert_allclose(g, expected_fisher, rtol=1e-08, atol=0)
 
-    @pytest.fixture(autouse=True)
-    def get_fisher_information(self, sample, model):
-        """Obtains the fisher matrix, and defines the used model parameters"""
-        self.xi = [sample[1].thick, sample[2].thick, sample[1].rough, sample[2].rough]
-        self.g = fisher(self.qs, self.xi, self.counts, [model])
+    @pytest.mark.parametrize('model_params', (1, 2, 3, 4))
+    def test_fisher_shape(self, model_fixture, model_params):
+        """
+        Tests whether the shape of the Fisher information matrix remains correct when changing the
+        amount of parameters
+        """
+        layer1 = model_fixture.structure.components[1]
+        layer2 = model_fixture.structure.components[2]
+        xi_all = [layer1.rough, layer2.rough, layer1.thick, layer2.thick]
+        xi = xi_all[:model_params]
+        expected_shape = (len(xi), len(xi))
+        g = get_fisher_information(model_fixture, xi=xi)
+        np.testing.assert_array_equal(g.shape, expected_shape)
 
-    def test_elements_greater_than_zero(self):
-        """
-        Tests that all diagonal elements in the Fisher matrix are greater
-        than zero
-        """
-        np.testing.assert_array_less(np.zeros(len(self.g)), np.diag(self.g))
-
-    def test_fisher_matrix_size(self):
-        """
-        Tests that the obtained Fisher matrix has the correct size
-        """
-        matrix_size = [len(self.xi), len(self.xi)]
-        g_size = [len(self.g), len(self.g[0])]
-        np.testing.assert_equal(matrix_size, g_size)
+    @pytest.mark.parametrize('qs',
+                             ([[i / 1 for i in range(1)]],
+                              [[i / 24 for i in range(25)]],
+                              [[i / 49 for i in range(50)]],
+                              [[i / 149 for i in range(150)]]))
+    def test_fisher_diagonal_positive(self, model_fixture, qs):
+        """Tests whether the diagonal values in the Fisher information matrix are positively valued"""
+        g = get_fisher_information(model_fixture, qs=qs)
+        np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -33,7 +33,7 @@ class Test_Fisher():
     @pytest.fixture(autouse=True)
     def get_fisher_information(self, sample, model):
         """Obtains the fisher matrix, and defines the used model parameters"""
-        self.xi = [sample[1].thick, sample[2].thick, sample[1].rough]
+        self.xi = [sample[1].thick, sample[2].thick, sample[1].rough, sample[2].rough]
         self.g = fisher(self.qs, self.xi, self.counts, [model])
 
     def test_elements_greater_than_zero(self):

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -15,20 +15,6 @@ class MockXi:
 
     def __getitem__(self, index):
         return self._elements[index]
-
-    def __getattr__(self, name):
-        if name == "value":
-            return [element.value for element in self._elements]
-
-    def __setattr__(self, name, value):
-        if name == "value":
-            if len(value) != len(self._elements):
-                raise ValueError("Length of new values must match the original array length.")
-            for element, new_value in zip(self._elements, value):
-                element.value = new_value
-        else:
-            super().__setattr__(name, value)
-
     def __len__(self):
         return len(self._elements)
 

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -10,7 +10,8 @@ from refnx.reflect import SLD as SLD_refnx
 from refl1d.material import SLD as SLD_refl1d
 from unittest.mock import Mock, patch
 
-Q_VALUES=np.array([[0.1, 0.2, 0.4, 0.6, 0.8]])
+Q_VALUES = np.array([[0.1, 0.2, 0.4, 0.6, 0.8]])
+
 
 @pytest.fixture
 def refl1d_model():
@@ -21,10 +22,10 @@ def refl1d_model():
     layer2 = SLD_refl1d(rho=8, name='Layer 2')(thickness=150, interface=2)
     substrate = SLD_refl1d(rho=2.047, name='Substrate')(thickness=0,
                                                         interface=2)
-    layer1.thickness.pmp(10)  # Set 10% interval on bounds
-    layer2.thickness.pmp(10)
-    layer1.interface.pmp(10)
-    layer2.interface.pmp(10)
+    layer1.thickness.pm(10)
+    layer2.thickness.pm(10)
+    layer1.interface.pm(1)
+    layer2.interface.pm(1)
     sample = substrate | layer2 | layer1 | air
 
     # Define model
@@ -34,6 +35,7 @@ def refl1d_model():
                 layer2.thickness]
     return model
 
+
 @pytest.fixture
 def refnx_model():
     """Define a bilayer sample, and return the associated refnx model"""
@@ -42,9 +44,9 @@ def refnx_model():
     layer1 = SLD_refnx(4, name='Layer 1')(thick=60, rough=8)
     layer2 = SLD_refnx(8, name='Layer 2')(thick=150, rough=2)
     substrate = SLD_refnx(2.047, name='Substrate')(thick=0, rough=2)
-    layer1.thick.bounds = (40, 70)
-    layer2.thick.bounds = (100, 180)
-    layer1.rough.bounds = (6, 10)
+    layer1.thick.bounds = (50, 70)
+    layer2.thick.bounds = (140, 160)
+    layer1.rough.bounds = (7, 9)
     layer2.rough.bounds = (1, 3)
     sample = air | layer1 | layer2 | substrate
     model = refnx.reflect.ReflectModel(sample, scale=1, bkg=5e-6, dq=2)
@@ -53,12 +55,13 @@ def refnx_model():
                 layer2.thick]  # Default free model parameters
     return model
 
+
 @pytest.fixture
 def mock_refnx_model():
     """Define a bilayer sample, and return the associated refnx model"""
     # Define sample
     parameter_values = [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5,
-                                                                       2.5)]
+                                                                     2.5)]
     parameters = [
         Mock(spec=refnx.analysis.Parameter, value=value,
              bounds=Mock(lb=lb, ub=ub))
@@ -68,12 +71,13 @@ def mock_refnx_model():
     model.xi = parameters
     return model
 
+
 @pytest.fixture
 def mock_refl1d_model():
     """Define a bilayer sample, and return the associated refnx model"""
     # Define sample
     parameter_values = [(20, 15, 25), (50, 45, 55), (10, 7.5, 8.5), (2, 1.5,
-                                                                       2.5)]
+                                                                     2.5)]
     parameters = [
         Mock(spec=bumps.parameter.Parameter, value=value,
              bounds=Mock(limits=[lb, ub]))
@@ -83,29 +87,31 @@ def mock_refl1d_model():
     model.xi = parameters
     return model
 
+
 def get_fisher_information(model, xi=None, counts=None,
-                           qs=None, step=0.005):
+                           qs=Q_VALUES, step=0.005):
     """Obtains the Fisher matrix, and defines the used model parameters"""
-    # Provide default values for qs, counts and xi
-    if qs is None:
-        qs = Q_VALUES  # Define default array of qs
+    # Provide default values for counts and xi
     if counts is None:
         counts = [np.ones(len(qs[0])) * 100]  # Define 100 counts at each q
     if xi is None:
         xi = model.xi
     return fisher(qs, xi, counts, [model], step)
 
-def get_reflectivity_from_datapoints(data_points):
+
+def get_reflectivity_given_datapoints(data_points):
     """
-    Mocks the reflectivity values in the calculation, values are changed
-    between each call to mimic a changing parameter in the model. Value
-    should always be between 0 and 1.
+    Mocks the reflectivity values in the calculation for an arbitrary
+    amount of data points. The value at each data point is changed from the
+    initial value by a total of 0.47, mimicking a changing parameter in the
+    model. Value should always remain between 0 and 1.
     """
     r = list(np.linspace(1, 0, num=data_points))  # Reflectivity from 1 to 0
     while True:
-        r = [abs(value - 0.47) for value in r]  # Change reflectivity after
+        r = [abs(value - 0.41) for value in r]  # Change reflectivity after
         # each call
         yield r
+
 
 def get_mock_reflectivity():
     """
@@ -118,17 +124,18 @@ def get_mock_reflectivity():
         yield r[0]
         yield r[1]
 
+
 def test_fisher_workflow_refnx(refnx_model):
     """
-    Tests that all the calculated Fisher information matrix returns the expected values
-    for a given set of parameters
+    Tests that all the calculated Fisher information matrix returns the
+    expected values for a given set of parameters
     """
     g = get_fisher_information(refnx_model, step=0.005)
     expected_fisher = [
-        [1.29426077e-06, 1.12089534e-06, -1.67407318e-07, -9.89857761e-08],
-        [1.12089534e-06, 1.00559528e-06, -1.39622503e-07, -7.96457855e-08],
-        [-1.67407318e-07, -1.39622503e-07, 2.55843215e-08, 1.71903501e-08],
-        [-9.89857761e-08, -7.96457855e-08, 1.71903501e-08, 1.24669272e-08]
+        [5.17704306e-06, 2.24179068e-06, -5.02221954e-07, -7.91886209e-07],
+        [2.24179068e-06, 1.00559528e-06, -2.09433754e-07, -3.18583142e-07],
+        [-5.02221954e-07, -2.09433754e-07, 5.75647233e-08, 1.03142100e-07],
+        [-7.91886209e-07, -3.18583142e-07, 1.03142100e-07, 1.99470835e-07]
     ]
     np.testing.assert_allclose(g, expected_fisher, rtol=1e-08)
 
@@ -140,16 +147,17 @@ def test_fisher_workflow_refl1d(refl1d_model):
     """
     g = get_fisher_information(refl1d_model, step=0.005)
     expected_fisher = [
-        [7.16085407e-06, 1.29820479e-05, -8.81392856e-07, -5.67164020e-07],
-        [1.29820479e-05, 2.44043845e-05, -1.53347962e-06, -9.45044841e-07],
-        [-8.81392856e-07, -1.53347962e-06, 1.25317378e-07, 9.12663545e-08],
-        [-5.67164020e-07, -9.45044841e-07, 9.12663545e-08, 7.22781693e-08]
+        [4.58294661e-06, 2.07712766e-06, -4.23068571e-07, -6.80596824e-07],
+        [2.07712766e-06, 9.76175381e-07, -1.84017555e-07, -2.83513452e-07],
+        [-4.23068571e-07, -1.84017555e-07, 4.51142562e-08, 8.21397190e-08],
+        [-6.80596824e-07, -2.83513452e-07, 8.21397190e-08, 1.62625881e-07]
     ]
     np.testing.assert_allclose(g, expected_fisher, rtol=1e-08)
 
+
 @patch('hogben.utils.reflectivity')
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
-                                       "mock_refnx_model"))
+                                         "mock_refnx_model"))
 def test_fisher_correct_values(mock_reflectivity, model_class, request):
     """
     Tests that the values of the calculated Fisher information matrix
@@ -158,16 +166,19 @@ def test_fisher_correct_values(mock_reflectivity, model_class, request):
     model = request.getfixturevalue(model_class)
     xi = model.xi[:3]
     mock_reflectivity.side_effect = get_mock_reflectivity()
-    g_correct = [[1.28125, 0.5125, 25.625],
-                [0.5125, 0.205, 10.25],
-                [25.625, 10.25, 512.5]]
-    g_reference = get_fisher_information(model, xi = xi)
+    g_correct = [
+        [1.28125, 0.5125, 25.625],
+        [0.5125, 0.205, 10.25],
+        [25.625, 10.25, 512.5]
+    ]
+    g_reference = get_fisher_information(model, xi=xi)
     np.testing.assert_allclose(g_reference, g_correct, rtol=1e-08)
 
+
 @pytest.mark.parametrize('model_class', ("refl1d_model",
-                                       "refnx_model"))
+                                         "refnx_model"))
 @pytest.mark.parametrize('step', (0.01, 0.0075, 0.0025, 0.001, 0.0001))
-def test_fisher_consistent_steps(step,  model_class, request):
+def test_fisher_consistent_steps(step, model_class, request):
     """
     Tests whether the Fisher information remains mostly consistent when
     changing step size using the refnx model
@@ -177,9 +188,10 @@ def test_fisher_consistent_steps(step,  model_class, request):
     g_compare = get_fisher_information(model, step=step)
     np.testing.assert_allclose(g_reference, g_compare, rtol=1e-02, atol=0)
 
+
 @patch('hogben.utils.reflectivity')
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
-                                       "mock_refnx_model"))
+                                         "mock_refnx_model"))
 @pytest.mark.parametrize('model_params', (1, 2, 3, 4))
 def test_fisher_shape(mock_reflectivity, model_params, model_class, request):
     """
@@ -189,16 +201,16 @@ def test_fisher_shape(mock_reflectivity, model_params, model_class, request):
     model = request.getfixturevalue(model_class)
     xi = model.xi[:model_params]
 
-    qs = Q_VALUES
     mock_reflectivity.side_effect = get_mock_reflectivity()
 
     expected_shape = (model_params, model_params)
     g = get_fisher_information(None, xi=xi)
     np.testing.assert_array_equal(g.shape, expected_shape)
 
+
 @patch('hogben.utils.reflectivity')
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
-                                       "mock_refnx_model"))
+                                         "mock_refnx_model"))
 @pytest.mark.parametrize('qs',
                          (np.arange(0.001, 1.0, 0.25),
                           np.arange(0.001, 1.0, 0.10),
@@ -208,12 +220,13 @@ def test_fisher_diagonal_positive(mock_reflectivity, qs, model_class, request):
     """Tests whether the diagonal values in the Fisher information matrix
      are positively valued"""
     model = request.getfixturevalue(model_class)
-    mock_reflectivity.side_effect = get_reflectivity_from_datapoints(len(qs))
+    mock_reflectivity.side_effect = get_reflectivity_given_datapoints(len(qs))
     g = get_fisher_information(model, qs=[qs])
     np.testing.assert_array_less(np.zeros(len(g)), np.diag(g))
 
+
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
-                                       "mock_refnx_model"))
+                                         "mock_refnx_model"))
 @pytest.mark.parametrize('model_params', (1, 2, 3, 4))
 def test_fisher_no_data(model_params, model_class, request):
     """Tests whether a model with zero data points properly returns a
@@ -224,8 +237,9 @@ def test_fisher_no_data(model_params, model_class, request):
     g = get_fisher_information(model, qs=[qs], xi=xi)
     np.testing.assert_equal(g, np.zeros((len(xi), len(xi))))
 
+
 @pytest.mark.parametrize('model_class', ("mock_refl1d_model",
-                                       "mock_refnx_model"))
+                                         "mock_refnx_model"))
 @patch('hogben.utils.reflectivity')
 def test_fisher_no_parameters(mock_reflectivity, model_class, request):
     """Tests whether a model with zero data points properly returns a
@@ -233,4 +247,4 @@ def test_fisher_no_parameters(mock_reflectivity, model_class, request):
     model = request.getfixturevalue(model_class)
     mock_reflectivity.side_effect = get_mock_reflectivity()
     g = get_fisher_information(model, xi=[])
-    np.testing.assert_equal(g.shape, (0,0))
+    np.testing.assert_equal(g.shape, (0, 0))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -254,6 +254,27 @@ def test_fisher_no_parameters(mock_reflectivity, model_class, request):
     g = get_fisher_information([model], xi=[])
     np.testing.assert_equal(g.shape, (0, 0))
 
+@patch('hogben.utils.reflectivity')
+@pytest.mark.parametrize('model_class', ("mock_refl1d_model",
+                                         "mock_refnx_model"))
+def test_fisher_importance_correct_values(mock_reflectivity, model_class,
+                                       request):
+    """
+    Tests that the values of the calculated Fisher information matrix
+    are calculated correctly.
+    """
+    model = request.getfixturevalue(model_class)
+    xi = model.xi[:3]
+    for index, param in enumerate(xi):
+        param.importance = index + 1
+    mock_reflectivity.side_effect = get_mock_reflectivity()
+    g_correct = [
+        [1.28125, 1.025, 76.875],
+        [0.5125, 0.41, 30.75],
+        [25.625, 20.5, 1537.5]
+    ]
+    g_reference = get_fisher_information([model], xi=xi)
+    np.testing.assert_allclose(g_reference, g_correct, rtol=1e-08)
 
 @pytest.mark.parametrize('model_class', ("refnx_model",
                                          "refl1d_model"))

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -50,7 +50,7 @@ def get_mock_reflectivity(data_points):
     Mocks the reflectivity values in the calculation, values are changed between each call
     to mimic a changing parameter in the model. Value should always be between 0 and 1.
     """
-    r = [i / data_points for i in range(data_points)]  # Create reflectivity values from 0 to 1
+    r = [i / data_points for i in range(data_points+1)]  # Create reflectivity values from 0 to 1
     while True:
         r = [abs(value - 0.43) for value in r]  # Change reflectivity after each call
         yield r

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -100,11 +100,12 @@ def mock_refl1d_model():
 
 def get_fisher_information(models,
                            xi: Optional[
-                               list[Union['refnx.reflect.ReflectModel',
-                               'refl1d.experiment.Experiment']]] = None,
+                               list[
+                                Union['refnx.reflect.ReflectModel',
+                                      'refl1d.experiment.Experiment']]] = None,
                            counts: Optional[list[int]] = None,
-                           qs: Optional[list[list]] = None,
-                           step: float = 0.005):
+                           qs: Optional[list[list[float]]] = None,
+                           step: float = 0.005) -> np.ndarray:
     """
     Obtains the Fisher matrix given a specified model, the optional
     parameters are given a default value if not specified.

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -155,7 +155,6 @@ def fisher(qs, xi, counts, models, step=0.005):
     """
     J = get_gradient(xi, step, models, qs)
     # Calculate the reflectance for each model for the given Q values.
-    ref1 = reflectivity(qs, models)
     r = np.concatenate([reflectivity(q, model)
                         for q, model in list(zip(qs, models))])
 
@@ -167,7 +166,6 @@ def fisher(qs, xi, counts, models, step=0.005):
     # scale each parameter's information by its "importance".
     if len(xi) > 1:
         lb, ub = get_bounds(xi)
-
         # Using the equations from the paper for the coordinate transform.
         H = np.diag(1/(ub-lb))
         g = np.dot(np.dot(H.T, g), H)

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -198,7 +198,7 @@ def _get_bounds(xi: list):
     return lb, ub
 
 def _get_gradient_matrix(xi: list, step: float, models: list, qs: list):
-    """Get the bounds from the list of parameters
+    """Get the gradient matrix of the reflectances
     Args:
         xi(list): varying model parameters
         step (float): step size to take when calculating gradient.

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -143,7 +143,7 @@ class Sampler:
         return fig
 
 
-def fisher(qs: list[list],
+def fisher(qs: list[list[float]],
            xi: list[Union['refnx.analysis.Parameter',
                           'bumps.parameter.Parameter']],
            counts: list[int],

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -143,7 +143,7 @@ class Sampler:
         return fig
 
 
-def fisher(qs: list[list[float]],
+def fisher(qs: list[np.ndarray],
            xi: list[Union['refnx.analysis.Parameter',
                           'bumps.parameter.Parameter']],
            counts: list[int],

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -143,9 +143,9 @@ def fisher(qs, xi, counts, models, step=0.005):
        containing parameters `xi`.
 
     Args:
-        qs (list): Q points for each model.
+        qs (list[list]): Q points for each model.
         xi (list): varying model parameters.
-        counts (list): incident neutron counts corresponding to each Q value.
+        counts (list[list]): incident neutron counts corresponding to each Q value.
         models (list): models to calculate gradients with.
         step (float): step size to take when calculating gradient.
 
@@ -165,19 +165,21 @@ def fisher(qs, xi, counts, models, step=0.005):
     # for every model data point.
     for i in range(m):
         parameter = xi[i]
-        old = parameter.value
+        original = parameter.value
 
         # Calculate reflectance for each model for first part of gradient.
-        x1 = parameter.value = old*(1-step)
+        parameter.value = original*(1-step)
+        x1 = parameter.value
         y1 = np.concatenate([reflectivity(q, model)
                              for q, model in list(zip(qs, models))])
 
         # Calculate reflectance for each model for second part of gradient.
-        x2 = parameter.value = old*(1+step)
+        parameter.value = original*(1+step)
+        x2 = parameter.value
         y2 = np.concatenate([reflectivity(q, model)
                              for q, model in list(zip(qs, models))])
 
-        parameter.value = old # Reset the parameter.
+        parameter.value = original # Reset the parameter.
 
         J[:,i] = (y2-y1) / (x2-x1) # Calculate the gradient.
 

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -184,7 +184,6 @@ def fisher(qs: list[list],
     # Calculate the gradient of model reflectivity with every model parameter
     # for every model data point.
     for i, parameter in enumerate(xi):
-        parameter = xi[i]
         old = parameter.value
 
         # Calculate reflectance for each model for first part of gradient.
@@ -252,4 +251,3 @@ def save_plot(fig, save_path, filename):
 
     file_path = os.path.join(save_path, filename + '.png')
     fig.savefig(file_path, dpi=600)
-

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -154,7 +154,7 @@ def fisher(qs: list, xi: list, counts: list, models: list, step: float=0.005):
 
     """
     n = sum(len(q) for q in qs)  # Number of data points.
-    m =  # Number of parameters.
+    m = len(xi)  # Number of parameters.
 
     # There is no information if there is no data.
     if n == 0:

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -163,7 +163,7 @@ def fisher(qs, xi, counts, models, step=0.005):
 
     # Calculate the gradient of model reflectivity with every model parameter
     # for every model data point.
-    for i in range(m):
+    for i, parameter in enumerate(xi):
         parameter = xi[i]
         original = parameter.value
 

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -229,8 +229,8 @@ def fisher(qs: list[np.ndarray],
                 importance_array.append(1)
         importance = np.diag(importance_array)
         H = np.diag(1 / (ub - lb))  # Get unit scaling Jacobian.
-        g = np.dot(np.dot(H.T, g), H) # Perform unit scaling.
-        g = np.dot(g, importance) # Perform importance scaling.
+        g = np.dot(np.dot(H.T, g), H)  # Perform unit scaling.
+        g = np.dot(g, importance)  # Perform importance scaling.
 
         # Return the Fisher information matrix.
     return g


### PR DESCRIPTION
Fixes issue #53 

In this current PR the following unit tests are performed for the `fisher` function:

 - `test_fisher_information_values` tests for a known case whether the calculated values are still correct
 - `test_fisher_shape` Tests whether the shape of the fisher matrix remains correct when using different model parameters
 - `test_fisher_diagonal_positive` tests for varying sets of q-values whether the diagonal elements are greater than zero. As far as I understood, these diagonal elements represent the FI for the individual parameter on this row, and should never be zero.
 
Also, the triple assignments in `fisher` function have been removed, and the associated docstring now indicates the list type for `qs` and `counts` (a list of list),

 I refactored the general structure of the unit test quite a bit since this morning, moving the `get_fisher_information` outside of the testing Class, as to allow to test for different cases. Given it's a cheap calculation, it is probably still worth it to just calculate g in each test.

There's probably a few more tests that could be added as well, such as the importance scaling and the gradient calculations. But I figured those may be added in a separate PR: