### PR TITLE
Add iSLD to converter functions

### DIFF
--- a/hogben/models/samples.py
+++ b/hogben/models/samples.py
@@ -257,7 +257,8 @@ class Sample(BaseSample):
             sld, sld_imag = component.sld.real.value, component.sld.imag.value
             thick, rough = component.thick.value, component.rough.value
 
-            # Add the component in the opposite direction to the refnx definition.
+            # Add the component in the opposite direction to the refnx
+            # definition.
             layer = refl1d.material.SLD(rho=sld, irho=sld_imag, name=name)(
                 thick, rough)
             structure = layer | structure
@@ -280,9 +281,10 @@ class Sample(BaseSample):
                 Parameter(component.material.irho.value)
             thick, rough = component.thickness.value, component.interface.value
 
-            # Add the component in the opposite direction to the Refl1D definition.
-            structure |= refnx.reflect.SLD([sld, sld_imag], name=name)(thick,
-                                                                   rough)
+            # Add the component in the opposite direction to the Refl1D
+            # definition.
+            structure |= refnx.reflect.SLD([sld, sld_imag], name=name)(
+                thick, rough)
 
         # Update the current structure to use the new version.
         structure.name = self.structure.name


### PR DESCRIPTION
Closes issue #68.

Adds the imaginary part of the SLD to the `to_refnx` and `to_refl1d` functions, such that this component is properly transferred over as well.  For the refnx syntax, see the docs: https://refnx.readthedocs.io/en/latest/refnx.reflect.html#refnx.reflect.SLD

Where the parameters have to be added as argument as a Parameter type:

```
>>> re = Parameter(3.47)
>>> im = Parameter(0.01)
>>> sio2 = SLD([re, im])
```

In this particular case, refl1d syntax is actually pretty straightforward. These changes in this method have been tested with the unit tests in PR #69.