### PR TITLE
Add docstrings to linter

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.10"
       # Install flake8 extensions (this step is not required. Default is "None").
       - name: Set up flake8
-        run: pip install flake8-quotes
+        run: pip install flake8-quotes flake8-docstring-checker
       - name: flake8 Lint
         run: |
          flake8 hogben

--- a/hogben/__init__.py
+++ b/hogben/__init__.py
@@ -1,3 +1,3 @@
-"""Top-level package for HOGBEN"""
+"""Top-level package for HOGBEN."""
 
 __version__ = '1.2.1'

--- a/hogben/angles.py
+++ b/hogben/angles.py
@@ -1,9 +1,13 @@
+"""
+Functions for visualizing and optimizing angle choice for a given sample.
+"""
 import os
 import time
 
 import numpy as np
 
 from hogben.optimise import Optimiser
+from models.samples import simple_sample
 from hogben.visualise import angle_choice, angle_choice_with_time
 
 
@@ -11,12 +15,11 @@ def _angle_results_visualise(save_path):
     """Visualises the initial angle choice for a sample and how the choice of
        next angle changes as the counting time of the initial angle increases.
 
+
     Args:
         save_path (str): path to directory to save results to.
 
     """
-    from models.samples import simple_sample
-
     # Choose sample here.
     sample = simple_sample()
 
@@ -46,7 +49,6 @@ def _angle_results_optimise(save_path):
         save_path (str): path to directory to save results to.
 
     """
-    from models.samples import simple_sample
     # Choose sample here.
     sample = simple_sample()
 

--- a/hogben/contrasts.py
+++ b/hogben/contrasts.py
@@ -1,3 +1,7 @@
+"""
+Functions for visualizing and optimizing angle choice for a given sample.
+"""
+
 import os
 import time
 
@@ -7,6 +11,7 @@ import numpy as np
 from hogben.optimise import Optimiser
 from hogben.visualise import contrast_choice_single, contrast_choice_double
 from hogben.utils import save_plot
+from models.bilayers import BilayerDMPC, BilayerDPPC
 
 
 def _contrast_results_visualise(save_path):
@@ -16,7 +21,6 @@ def _contrast_results_visualise(save_path):
         save_path (str): path to directory to save results to.
 
     """
-    from models.bilayers import BilayerDMPC
 
     # Choose sample here.
     bilayer = BilayerDMPC()
@@ -52,8 +56,6 @@ def _contrast_results_optimise(save_path):
         save_path (str): path to directory to save results to.
 
     """
-    from bilayers import BilayerDMPC
-
     # Choose sample here.
     bilayer = BilayerDMPC()
 
@@ -111,8 +113,6 @@ def _figure_2(save_path):
         save_path (str): path to directory to save figure to.
 
     """
-    from bilayers import BilayerDMPC, BilayerDPPC
-
     # Load the two bilayer models.
     sample_1, sample_2 = BilayerDMPC(), BilayerDPPC()
 

--- a/hogben/data/__init__.py
+++ b/hogben/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data package for HOGBEN."""

--- a/hogben/data/directbeams/__init__.py
+++ b/hogben/data/directbeams/__init__.py
@@ -1,0 +1,1 @@
+"""directbeam package for the data module."""

--- a/hogben/data/directbeams/make_beam_spectra.py
+++ b/hogben/data/directbeams/make_beam_spectra.py
@@ -1,9 +1,12 @@
+"""Module to create valid beam spectra for a given set of instruments."""
+
 # Load files and do flood correction
 # import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
 
 
 def pre_process(runno, detectors='75-95'):
+    """Pre-process data"""
     LoadISISNexus(
         str(runno), OutputWorkspace=str(runno), LoadMonitors='Exclude'
     )

--- a/hogben/kinetics.py
+++ b/hogben/kinetics.py
@@ -1,3 +1,6 @@
+"""Functions for visualizing and optimizing angle and contrast for kinetic
+experiments."""
+
 import numpy as np
 import os
 

--- a/hogben/magnetism.py
+++ b/hogben/magnetism.py
@@ -1,3 +1,6 @@
+"""Functions for visualizing and optimizing angle and contrast for magnetic
+experiments."""
+
 import matplotlib.pyplot as plt
 import os
 

--- a/hogben/models/__init__.py
+++ b/hogben/models/__init__.py
@@ -1,0 +1,1 @@
+"""Models package for HOGBEN."""

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -1,3 +1,5 @@
+"""Base classes for different sample types """
+
 import os
 from abc import ABC, abstractmethod
 from typing import Optional
@@ -73,6 +75,10 @@ class BaseLipid(BaseSample, VariableContrast, VariableUnderlayer):
     """Abstract class representing the base class for a lipid model."""
 
     def __init__(self):
+        """
+        Initialize a BaseLipid object sample, and loads the
+        experimentally measured data
+        """
         self._create_objectives()  # Load experimentally-measured data.
 
     @abstractmethod

--- a/hogben/models/bilayers.py
+++ b/hogben/models/bilayers.py
@@ -1,3 +1,5 @@
+"""Contains the classes for different types of lipid bilayers"""
+
 import os
 
 import matplotlib.pyplot as plt

--- a/hogben/models/magnetic.py
+++ b/hogben/models/magnetic.py
@@ -1,3 +1,5 @@
+"""Contains the class to define magnetic samples"""
+
 import os
 
 import matplotlib.pyplot as plt

--- a/hogben/models/monolayers.py
+++ b/hogben/models/monolayers.py
@@ -1,3 +1,6 @@
+"""Contains the class for monolayer samples"""
+
+
 import os
 from typing import Optional
 

--- a/hogben/models/parsing.py
+++ b/hogben/models/parsing.py
@@ -1,3 +1,5 @@
+"""Functions to parse a chemical formula from a string as a dictionary"""
+
 __author__ = 'github.com/arm61'
 
 import re

--- a/hogben/models/samples.py
+++ b/hogben/models/samples.py
@@ -1,3 +1,7 @@
+"""
+Contains class and methods related to the Sample class.
+"""
+
 import os
 import matplotlib.pyplot as plt
 
@@ -37,6 +41,13 @@ class Sample(BaseSample):
     """
 
     def __init__(self, structure):
+        """
+        Initializes a sample given a structure, and sets the sample name and
+        parameters
+
+        Args:
+            structure: Sample structure defined in the refnx or refl1d model
+        """
         self.structure = structure
         self.name = structure.name
         self.params = Sample.__vary_structure(structure)

--- a/hogben/optimise.py
+++ b/hogben/optimise.py
@@ -1,8 +1,12 @@
+"""Module containing the Optimiser class used to optimise a neutron
+reflectometry experiment"""
+
 import numpy as np
 
 from scipy.optimize import differential_evolution, NonlinearConstraint
 
 from hogben.models.base import (
+    BaseSample,
     VariableAngle,
     VariableContrast,
     VariableUnderlayer,
@@ -17,7 +21,13 @@ class Optimiser:
 
     """
 
-    def __init__(self, sample):
+    def __init__(self, sample: BaseSample):
+        """
+        Initializes Optimiser given a sample
+
+        Args:
+            sample: The sample to optimise an experiment for
+        """
         self.sample = sample
 
     def optimise_angle_times(
@@ -58,14 +68,23 @@ class Optimiser:
 
         # Constrain the counting times to sum to the fixed time budget.
         # Also constrain the angles to be in non-decreasing order.
-        def sum_of_splits(x):
+        def _sum_of_splits(x):
+            """
+            Sets the constraint for the counting times to the sum of the
+            fixed time budget
+            """
             return sum(x[num_angles:])
 
-        def non_decreasing(x):
+        def _non_decreasing(x):
+            """
+            Sets the constraint for the angles to be in non-decreasing
+            order
+            """
             return int(np.all(np.diff(x[:num_angles]) >= 0))
 
-        constraints = [NonlinearConstraint(sum_of_splits, 1, 1),
-                       NonlinearConstraint(non_decreasing, 1, 1)]
+        # Set both constrains as equality constraints
+        constraints = [NonlinearConstraint(_sum_of_splits, 1, 1),
+                       NonlinearConstraint(_non_decreasing, 1, 1)]
 
         # Optimise angles and times, and return the results.
         res, val = Optimiser.__optimise(self._angle_times_func, bounds,
@@ -105,15 +124,24 @@ class Optimiser:
 
         # Constrain the counting times to sum to the fixed time budget.
         # Also constrain the contrasts to be in non-decreasing order.
-        def sum_of_splits(x):
+        def _sum_of_splits(x):
+            """
+            Sets the constraint for the counting times to the sum of the
+            fixed time budget
+            """
             return sum(x[num_contrasts:])
 
-        def non_decreasing(x):
+        def _non_decreasing(x):
+            """
+            Sets the constraint for the contrasts to be in non-decreasing
+            order
+            """
             return int(np.all(np.diff(x[:num_contrasts]) >= 0))
 
+        # Set both constrains as equality constraints
         constraints = [
-            NonlinearConstraint(sum_of_splits, 1, 1),
-            NonlinearConstraint(non_decreasing, 1, 1),
+            NonlinearConstraint(_sum_of_splits, 1, 1),
+            NonlinearConstraint(_non_decreasing, 1, 1),
         ]
 
         # Arguments for the optimisation function.

--- a/hogben/simulate.py
+++ b/hogben/simulate.py
@@ -1,3 +1,5 @@
+"""Methods used to simulate an experiment """
+
 import os.path
 from typing import Optional, Union
 

--- a/hogben/tests/__init__.py
+++ b/hogben/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Testing package for HOGBEN."""

--- a/hogben/tests/test_fisher.py
+++ b/hogben/tests/test_fisher.py
@@ -1,3 +1,5 @@
+"""Unit tests for the methods that relate directly to the Fisher information"""
+
 import copy
 
 import bumps.parameter

--- a/hogben/tests/test_simulation.py
+++ b/hogben/tests/test_simulation.py
@@ -1,3 +1,5 @@
+"""Tests for the simulation module"""
+
 import pytest
 
 import numpy as np

--- a/hogben/underlayers.py
+++ b/hogben/underlayers.py
@@ -1,3 +1,8 @@
+"""
+Functions for visualizing and optimizing the choice of underlayer thickness
+and SLD for a given bilayer sample.
+"""
+
 import os
 import time
 
@@ -5,6 +10,7 @@ import numpy as np
 
 from hogben.optimise import Optimiser
 from hogben.visualise import underlayer_choice
+from models.bilayers import BilayerDMPC
 
 
 def _underlayer_results_visualise(save_path):
@@ -14,7 +20,6 @@ def _underlayer_results_visualise(save_path):
         save_path (str): path to directory to save results to.
 
     """
-    from models.bilayers import BilayerDMPC
 
     # Choose sample here.
     bilayer = BilayerDMPC()
@@ -55,7 +60,6 @@ def _underlayer_results_optimise(save_path):
         save_path (str): path to directory to save results to.
 
     """
-    from bilayers import BilayerDMPC
 
     # Choose sample here.
     bilayer = BilayerDMPC()

--- a/hogben/utils.py
+++ b/hogben/utils.py
@@ -1,3 +1,6 @@
+"""General utility functions to run nested sampling, calculate the Fisher
+information, and save plots"""
+
 import os
 from typing import Union
 
@@ -30,6 +33,12 @@ class Sampler:
     """
 
     def __init__(self, objective):
+        """
+        Initialise the sample given an objective to the sample
+
+        Args:
+            objective: objective to the sample
+        """
         self.objective = objective
 
         # Determine if the objective is from refnx or Refl1D.

--- a/hogben/visualise.py
+++ b/hogben/visualise.py
@@ -1,3 +1,6 @@
+"""Methods to visualise the optimised experimental conditions using a saved
+plot"""
+
 import os
 import numpy as np
 import matplotlib.pyplot as plt
@@ -117,13 +120,14 @@ def angle_choice_with_time(
     # Create the line that will have data added to it.
     (line,) = ax.plot([], [], lw=3)
 
-    # Initialiser function for the line.
     def init():
+        """Initialiser function for the line"""
         line.set_data([], [])
         return line,
 
     # Annimation function for the line.
     def animate(i):
+        """Describes how the function should be animated"""
         # Display progress.
         if i % 5 == 0:
             print('>>> {0}/{1}'.format(i, len(time_range)))

--- a/notebooks/angle.ipynb
+++ b/notebooks/angle.ipynb
@@ -18,8 +18,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-06T11:13:54.116151155Z",
+     "start_time": "2023-09-06T11:13:52.397174141Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from IPython.display import HTML\n",
@@ -48,8 +53,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-06T11:13:54.129007283Z",
+     "start_time": "2023-09-06T11:13:54.120445447Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Defines a structure describing a simple sample.\n",
@@ -74,8 +84,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-06T11:13:55.921473994Z",
+     "start_time": "2023-09-06T11:13:55.915357948Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Path to directory to save results to.\n",


### PR DESCRIPTION
Adds `flake8-docstring-checker` to the linter. This currently simply check for each module and method that a docstring exists at all.

It checks every single module and method, including init functions. I looked around, and indeed all conventions (including Google's, numpy and PEP) state that also the init function should contain a docstring, it follows the same rules as other methods. Some added docstrings may need some feedback, as it was not completely trivial what `make_beam_spectra` does exactly for instance.

In the future it may be useful to use `flake8-docstrings` instead ([see description](https://github.com/pycqa/flake8-docstrings)). Which checks the actual contents into more detail But there we need to specify a specific convention, and it tries to enforce this quite harshly. This means for instance that every single docstring for instance needs to start with a single line (within 79 characters, minus indentation and quote signs) with a short description, followed by a blank line and then a longer description.

But before reformatting all those docstrings, it's probably good to first decide on a standard, and how strongly this should be followed. So for now I just added the simpler docstring-checker, which gives a bit more freedom to how the docstrings should be written.