### PR TITLE
Use reviewdog in linter

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -37,5 +37,7 @@ jobs:
       - name: Set up flake8
         run: pip install flake8-quotes flake8-docstring-checker
       - name: flake8 Lint
-        run: |
-         flake8 hogben
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_error: true


### PR DESCRIPTION
My last changes to the linter for now. This executes flake8 with `action-flake8`, which outputs the linting errors with the Files changed in Github. We use this in [Graphs](https://github.com/Sjoerd1993/Graphs/) as well, and I always found it very convenient. See related screenshot:

![Screenshot from 2023-09-06 14-46-18](https://github.com/James-Durant/experimental-design/assets/68477016/dfc18710-5003-465f-b3ef-b73492a9af03)
