### PR TITLE
Use flake8-docstrings

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.10"
       # Install flake8 extensions (this step is not required. Default is "None").
       - name: Set up flake8
-        run: pip install flake8-quotes flake8-docstring-checker
+        run: pip install flake8-quotes flake8-docstrings
       - name: flake8 Lint
         uses: reviewdog/action-flake8@v3
         with:

--- a/hogben/models/bilayers.py
+++ b/hogben/models/bilayers.py
@@ -74,6 +74,7 @@ class BilayerPOPC(BaseLipid):
     """
 
     def __init__(self):
+        """Initialise BilayerPOPC sample and set the sample properties"""
         self.name = 'POPC_bilayer'
         self.data_path = os.path.join(
             os.path.dirname(__file__), '..', 'data', 'POPC_bilayer'
@@ -336,6 +337,7 @@ class BilayerDMPC(BaseLipid):
     """
 
     def __init__(self):
+        """Initialise BilayerDMPC sample and set the sample properties"""
         self.name = 'DMPC_bilayer'
         self.data_path = os.path.join(
             os.path.dirname(__file__), '..', 'data', 'DMPC_bilayer'
@@ -617,6 +619,7 @@ class BilayerDPPC(BaseLipid):
     """
 
     def __init__(self):
+        """Initialise BilayerDPPC sample and set the sample properties"""
         self.name = 'DPPC_RaLPS_bilayer'
         self.data_path = os.path.join(
             os.path.dirname(__file__), '..', 'data', 'DPPC_RaLPS_bilayer'

--- a/hogben/models/magnetic.py
+++ b/hogben/models/magnetic.py
@@ -58,6 +58,7 @@ class SampleYIG(BaseSample, VariableUnderlayer):
     """
 
     def __init__(self):
+        """Initialise YIG sample and set the sample properties"""
         self.name = 'YIG_sample'
         self.data_path = os.path.join(
             os.path.dirname(__file__), '..', 'data', 'YIG_sample'

--- a/hogben/models/monolayers.py
+++ b/hogben/models/monolayers.py
@@ -43,6 +43,7 @@ class MonolayerDPPG(BaseLipid):
     """
 
     def __init__(self, deuterated: bool = False):
+        """Initialise a DPPG monolayer sample and set the sample properties"""
         self.name = 'DPPG_monolayer'
         self.data_path = os.path.join(
             os.path.dirname(__file__), '..', 'data', 'DPPG_monolayer'

--- a/hogben/tests/test_simulation.py
+++ b/hogben/tests/test_simulation.py
@@ -20,6 +20,10 @@ def sample_structure():
 
 
 class Test_Simulate():
+    """
+    Contains the unit tests and attributes that are used to test the
+    simulate module
+    """
     ref = 'OFFSPEC'
     angle_times = [(0.7, 100, 5), (2.0, 100, 20)]  # (Angle, Points, Time)
     scale = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 
 [flake8]
 count = True
-ignore = E741, W503, W605
+ignore = E741, W503, W605, D2, D3, D4
 inline-quotes = single
 
 # `make_beam_spectra.py` uses a blank star import (F403), 


### PR DESCRIPTION
Switches out `flake8-docstring-checker` with `flake8-docstrings`. The main issue with the former is that reviewdog does not detect any errors, which I suspect is due to the error code. All other flake8 extensions use a single character, followed by a number, but `flake8-docstring-checker` uses two characters. I've reported this issue in the reviewdog repo.

This PR switches to `flake8-docstrings` instead, which does work properly with reviewdog. This extension is also larger, both in scope and userbase, with a bigger development team and user base. So that's also and advantage. 

I've turned off the checks for the docstring contents, so that it only checks if there's a docstring at all. So this PR should not change anything in the actual workflow behaviour. See for a full error list of things it can report [here.](http://www.pydocstyle.org/en/latest/error_codes.html#). Right now everything other than the "Missing docstrings" category has been turned off. This also allows us to enable certain checks later on a granular level if we want to simply by enabling a specific error code, without having to add any new extensions to the linter.

The previous module seems to have missed a few cases somehow, which are added in this PR.