### PR TITLE
Fix contrast test

### DIFF
--- a/hogben/tests/test_optimise.py
+++ b/hogben/tests/test_optimise.py
@@ -115,7 +115,7 @@ def test_contrasts_func_result():
     result = optimiser._contrasts_func(contrasts_time, num_contrasts,
                                        angle_splits, total_time)
 
-    expected_result = -2.55788110
+    expected_result = -0.199884
     np.testing.assert_allclose(result, expected_result, rtol=1e-06)
 
 

--- a/hogben/tests/test_optimise.py
+++ b/hogben/tests/test_optimise.py
@@ -106,7 +106,7 @@ def test_angle_times_func_result(refnx_sample):
 
 def test_contrasts_func_result():
     """Checks that the _contrasts_func method gives the correct result"""
-    contrasts_time = [0.3, 9.3, 0.8, 8.2]  # [SLD, SLD, time, time]
+    contrasts_time = [0.3, 9.3, 0.8, 0.2]  # [SLD, SLD, time, time]
     num_contrasts = 2
     angle_splits = [(0.7, 100, 0.6), (2.3, 100, 0.4)]
     total_time = 100000


### PR DESCRIPTION
Found the issue why I was getting unrealistic values for the `angle_times` in the unit-test, the time-fraction of one of the contrasts was set at 8.2 instead of 0.2...

Fixed the number in this PR.