### PR TITLE
Update email in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or with BibTeX as:
 ```
 
 ## Contact
-Jos Cooper - jos.cooper@ess.eu \
+Jos Cooper - joshaniel.cooper@ess.eu \
 Sjoerd Stendahl - sjoerd.stendahl@physics.uu.se \
 James Durant - james.durant@warwick.ac.uk \
 Lucas Wilkins - lucas.wilkins@stfc.ac.uk


### PR DESCRIPTION
Seems jos.cooper@ess.se is (no longer?) working. According to the profile online it should be Joshaniel.Cooper@ess.eu now. If that's the case, then this just updates that.