### PR TITLE
run CI even if the target branch is the fork

### DIFF
--- a/.github/workflows/automated-testing.yml
+++ b/.github/workflows/automated-testing.yml
@@ -2,9 +2,10 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
+      - jfkcooper:main
   workflow_dispatch:
   
 name: CI


### PR DESCRIPTION
The PRs are not running the CI as it's tripping up at a very weird corner case. PR opened to be merged into `jfkcooper:main` won't start up the CI service. This should probably fix it.