### PR TITLE
Moved where zeros are filtered to next to where this is needed (when applying nested sampling)

### DIFF
--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -420,6 +420,8 @@ class BaseLipid(BaseSample, VariableContrast, VariableUnderlayer):
             model.bkg = background_level
             model.dq = 2
             data = SimulateReflectivity(model, angle_times).simulate()
+            # filter zeros as nested sampling doesn't deal with these well
+            data = data[:, (data[1] != 0)]
 
             dataset = refnx.dataset.ReflectDataset(
                 [data[0], data[1], data[2]]

--- a/hogben/models/samples.py
+++ b/hogben/models/samples.py
@@ -410,6 +410,8 @@ class Sample(BaseSample):
         for structure in self.structures:
             model = refnx.reflect.ReflectModel(structure)
             data = SimulateReflectivity(model, angle_times).simulate()
+            # filter zeros as nested sampling doesn't deal with these well
+            data = data[:, (data[1] != 0)]
             objective = Objective(model, data)
             objectives.append(objective)
         global_objective = GlobalObjective(objectives)

--- a/hogben/simulate.py
+++ b/hogben/simulate.py
@@ -103,9 +103,6 @@ class SimulateReflectivity:
             self._run_experiment(*condition, polarised) for condition in self.angle_times
         ])
 
-        # filter zeros
-        simulation = simulation[:, (simulation[1] != 0)]
-
         # order by q
         simulation = simulation[:, np.argsort(simulation[0])]
 

--- a/hogben/tests/test_simulation.py
+++ b/hogben/tests/test_simulation.py
@@ -107,6 +107,22 @@ class TestSimulate:
 
             sim_not_in_pol._incident_flux_data(polarised=True)
 
+    def test_number_of_points(self, refnx_model):
+        """
+        Tests that the number of points generated in the simulation is what we define
+        (even when many are zero)
+        """
+        NPOINTS = 100
+        angle_times = [(0.3, NPOINTS, 10000)]
+        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
+        assert len(sim[0]) == NPOINTS
+        angle_times = [(0.3, NPOINTS, 5)]
+        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
+        assert len(sim[0]) == NPOINTS
+        angle_times = [(0.3, NPOINTS, 5), (2.0, NPOINTS, 50)]
+        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
+        assert len(sim[0]) == NPOINTS*2
+
     def test_reflectivity(self, refnx_model):
         """
         Checks that a refnx model reflectivity generated through

--- a/hogben/tests/test_simulation.py
+++ b/hogben/tests/test_simulation.py
@@ -109,19 +109,22 @@ class TestSimulate:
 
     def test_number_of_points(self, refnx_model):
         """
-        Tests that the number of points generated in the simulation is what we define
-        (even when many are zero)
+        Tests that the number of points generated in the
+        simulation is what we define (even when many are zero)
         """
         NPOINTS = 100
         angle_times = [(0.3, NPOINTS, 10000)]
-        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
+        sim = SimulateReflectivity(refnx_model,
+                                   angle_times=angle_times).simulate()
         assert len(sim[0]) == NPOINTS
         angle_times = [(0.3, NPOINTS, 5)]
-        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
+        sim = SimulateReflectivity(refnx_model,
+                                   angle_times=angle_times).simulate()
         assert len(sim[0]) == NPOINTS
         angle_times = [(0.3, NPOINTS, 5), (2.0, NPOINTS, 50)]
-        sim = SimulateReflectivity(refnx_model, angle_times=angle_times).simulate()
-        assert len(sim[0]) == NPOINTS*2
+        sim = SimulateReflectivity(refnx_model,
+                                   angle_times=angle_times).simulate()
+        assert len(sim[0]) == NPOINTS * 2
 
     def test_reflectivity(self, refnx_model):
         """


### PR DESCRIPTION
This addresses #126 by moving where zero filtering is done so that we are able to simulate a consistent number of datapoints.