### PR TITLE
141 fixing issues with bilayer can't be simulated

### DIFF
--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -136,8 +136,8 @@ class BaseSample(VariableAngle):
         """
 
         dq_values = (self.dq
-                    if isinstance(self.dq, (list, tuple))
-                    else [self.dq] * len(self.structures))
+                     if isinstance(self.dq, (list, tuple))
+                     else [self.dq] * len(self.structures))
 
         return [
             refnx.reflect.ReflectModel(

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -139,7 +139,7 @@ class BaseSample(VariableAngle):
                                            bkg=bkg,
                                            dq=dq)
                 for structure, scale, bkg, dq
-                in zip(self.structures, self.scale, self.bkg, self.dq)]
+                in zip(self.structures, self.scale, self.bkg, [self.dq])
 
     def simulate_reflectivity(self, angle_times,
                               inst_or_path='OFFSPEC') -> None:

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -134,12 +134,20 @@ class BaseSample(VariableAngle):
         Generates a refnx `ReflectModel` for each structure associated with the
         all structures of the Sample, and returns these in a list.
         """
-        return [refnx.reflect.ReflectModel(structure,
-                                           scale=scale,
-                                           bkg=bkg,
-                                           dq=dq)
-                for structure, scale, bkg, dq
-                in zip(self.structures, self.scale, self.bkg, [self.dq])]
+
+        dq_values = self.dq if isinstance(self.dq, (list, tuple)) else [self.dq] * len(self.structures)
+
+        return [
+            refnx.reflect.ReflectModel(
+                structure,
+                scale=scale,
+                bkg=bkg,
+                dq=dq
+            )
+            for structure, scale, bkg, dq in zip(
+                self.structures, self.scale, self.bkg, dq_values
+            )
+        ]
 
     def simulate_reflectivity(self, angle_times,
                               inst_or_path='OFFSPEC') -> None:

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -135,7 +135,9 @@ class BaseSample(VariableAngle):
         all structures of the Sample, and returns these in a list.
         """
 
-        dq_values = self.dq if isinstance(self.dq, (list, tuple)) else [self.dq] * len(self.structures)
+        dq_values = (self.dq
+                    if isinstance(self.dq, (list, tuple))
+                    else [self.dq] * len(self.structures))
 
         return [
             refnx.reflect.ReflectModel(

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -139,7 +139,7 @@ class BaseSample(VariableAngle):
                                            bkg=bkg,
                                            dq=dq)
                 for structure, scale, bkg, dq
-                in zip(self.structures, self.scale, self.bkg, [self.dq])
+                in zip(self.structures, self.scale, self.bkg, [self.dq])]
 
     def simulate_reflectivity(self, angle_times,
                               inst_or_path='OFFSPEC') -> None:

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -131,23 +131,24 @@ class BaseSample(VariableAngle):
 
     def get_models(self) -> list:
         """
-        Generates a refnx `ReflectModel` for each structure associated with the
-        all structures of the Sample, and returns these in a list.
+        Generates a `ReflectModel` for each structure associated with the
+        Sample, and returns these in a list.
         """
-
-        dq_values = (self.dq
-                     if isinstance(self.dq, (list, tuple))
-                     else [self.dq] * len(self.structures))
+        dq_iter = (
+            self.dq
+            if isinstance(self.dq, (list, tuple))
+            else repeat(self.dq)
+        )
 
         return [
             refnx.reflect.ReflectModel(
                 structure,
                 scale=scale,
                 bkg=bkg,
-                dq=dq
+                dq=dq,
             )
             for structure, scale, bkg, dq in zip(
-                self.structures, self.scale, self.bkg, dq_values
+                self.structures, self.scale, self.bkg, dq_iter
             )
         ]
 

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -17,6 +17,8 @@ from refnx._lib import flatten
 
 from hogben.simulate import SimulateReflectivity
 from hogben.utils import Fisher, Sampler, save_plot
+from itertools import repeat
+
 
 plt.rcParams['figure.figsize'] = (9, 7)
 plt.rcParams['figure.dpi'] = 600

--- a/hogben/models/base.py
+++ b/hogben/models/base.py
@@ -133,8 +133,8 @@ class BaseSample(VariableAngle):
 
     def get_models(self) -> list:
         """
-        Generates a `ReflectModel` for each structure associated with the
-        Sample, and returns these in a list.
+        Generates a refnx `ReflectModel` for each structure associated with the
+        all structures of the Sample, and returns these in a list.
         """
         dq_iter = (
             self.dq

--- a/hogben/models/bilayers.py
+++ b/hogben/models/bilayers.py
@@ -121,21 +121,21 @@ class BilayerPOPC(BaseLipid):
         )
 
         self.params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
-            self.sio2_rough,
+            # self.sio2_rough,
             self.sio2_solv,
             self.popc_apm,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
 
         self.underlayer_params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
             self.popc_apm,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
@@ -382,21 +382,21 @@ class BilayerDMPC(BaseLipid):
         )
 
         self.params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
-            self.sio2_rough,
+            # self.sio2_rough,
             self.sio2_solv,
             self.dmpc_apm,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
 
         self.underlayer_params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
             self.dmpc_apm,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
@@ -676,13 +676,13 @@ class BilayerDPPC(BaseLipid):
         )
 
         self.params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
-            self.sio2_rough,
+            # self.sio2_rough,
             self.sio2_solv,
             self.inner_hg_thick,
             self.inner_hg_solv,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.inner_tg_thick,
             self.outer_tg_thick,
             self.tg_solv,
@@ -692,11 +692,11 @@ class BilayerDPPC(BaseLipid):
         ]
 
         self.underlayer_params = [
-            self.si_rough,
+            # self.si_rough,
             self.sio2_thick,
             self.inner_hg_thick,
             self.inner_hg_solv,
-            self.bilayer_rough,
+            # self.bilayer_rough,
             self.inner_tg_thick,
             self.outer_tg_thick,
             self.tg_solv,

--- a/hogben/models/bilayers.py
+++ b/hogben/models/bilayers.py
@@ -121,21 +121,16 @@ class BilayerPOPC(BaseLipid):
         )
 
         self.params = [
-            # self.si_rough,
             self.sio2_thick,
-            # self.sio2_rough,
             self.sio2_solv,
             self.popc_apm,
-            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
 
         self.underlayer_params = [
-            # self.si_rough,
             self.sio2_thick,
             self.popc_apm,
-            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
@@ -382,21 +377,16 @@ class BilayerDMPC(BaseLipid):
         )
 
         self.params = [
-            # self.si_rough,
             self.sio2_thick,
-            # self.sio2_rough,
             self.sio2_solv,
             self.dmpc_apm,
-            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
 
         self.underlayer_params = [
-            # self.si_rough,
             self.sio2_thick,
             self.dmpc_apm,
-            # self.bilayer_rough,
             self.bilayer_solv,
             self.hg_waters,
         ]
@@ -676,13 +666,10 @@ class BilayerDPPC(BaseLipid):
         )
 
         self.params = [
-            # self.si_rough,
             self.sio2_thick,
-            # self.sio2_rough,
             self.sio2_solv,
             self.inner_hg_thick,
             self.inner_hg_solv,
-            # self.bilayer_rough,
             self.inner_tg_thick,
             self.outer_tg_thick,
             self.tg_solv,
@@ -692,11 +679,9 @@ class BilayerDPPC(BaseLipid):
         ]
 
         self.underlayer_params = [
-            # self.si_rough,
             self.sio2_thick,
             self.inner_hg_thick,
             self.inner_hg_solv,
-            # self.bilayer_rough,
             self.inner_tg_thick,
             self.outer_tg_thick,
             self.tg_solv,

--- a/hogben/tests/test_optimise.py
+++ b/hogben/tests/test_optimise.py
@@ -156,7 +156,7 @@ def test_contrasts_func_result():
     result = optimiser._contrasts_func(contrasts_time, num_contrasts,
                                        angle_splits, total_time)
 
-    expected_result = -0.199884
+    expected_result = -4.345145
     np.testing.assert_allclose(result, expected_result, rtol=1e-06)
 
 
@@ -173,7 +173,7 @@ def test_underlayers_func():
     result = optimiser._underlayers_func(thickness_SLD, num_underlayers,
                                          angle_times, contrasts)
 
-    expected_result = -1.500100628
+    expected_result = -2.280329121
     np.testing.assert_allclose(result, expected_result, rtol=1e-06)
 
 


### PR DESCRIPTION
SImulate reflectivity with the model bilayer functions returned an error pointing to get_models, specifically the line:

                 in zip(self.structures, self.scale, self.bkg, self.dq)

All of these variable inputted as lists except dq which is an integer, which is creating the problem. A simple fix would is as proposed and seems to fix the issue, but is there a better way?

