### PR TITLE
Swapping substrate and solvent1/2 around in optimization notebook

### DIFF
--- a/notebooks/optimization.ipynb
+++ b/notebooks/optimization.ipynb
@@ -303,8 +303,8 @@
     "        param.vary = True\n",
     "    \n",
     "    # Create a structure, separating each layer with a `|`\n",
-    "    structure1 = solvent1 | layer3 | layer2 | layer1 | substrate\n",
-    "    structure2 = solvent2 | layer3 | layer2 | layer1 | substrate\n",
+    "    structure1 = substrate | layer3 | layer2 | layer1 | solvent1\n",
+    "    structure2 = substrate | layer3 | layer2 | layer1 | solvent2\n",
     "    \n",
     "    return [structure1, structure2]"
    ],
@@ -487,8 +487,8 @@
     "        param.vary = True\n",
     "    \n",
     "    # Create a structure, separating each layer with a `|`\n",
-    "    structure1 = solvent1 | layer3 | layer2 | layer1 | ref_layer | substrate\n",
-    "    structure2 = solvent2 | layer3 | layer2 | layer1 | ref_layer | substrate\n",
+    "    structure1 = substrate | layer3 | layer2 | layer1 | ref_layer | solvent1\n",
+    "    structure2 = substrate | layer3 | layer2 | layer1 | ref_layer | solvent2\n",
     "    \n",
     "    return [structure1, structure2]"
    ],


### PR DESCRIPTION
This was originally effectively treating the substrate as the solvent for the purpose of returning SLDs of layers with solvation, meaning optimisation for vf was failing.